### PR TITLE
Profile mode: Use mouse-click location as default for hyperbola plotting

### DIFF
--- a/gprpy/gprpyGUI.py
+++ b/gprpy/gprpyGUI.py
@@ -836,6 +836,9 @@ class GPRPyApp:
         def moved(event):
             if event.xdata is not None and event.ydata is not None:
                 canvas.get_tk_widget().itemconfigure(tag, text="(x = %5.5g, y = %5.5g)" % (event.xdata, event.ydata))
+                # use these coordinates as starting values for Hyperbolae
+                self.hypx = event.xdata
+                self.hypt = event.ydata
                 
         self.cursor_cid = canvas.mpl_connect('button_press_event', moved)
         tag = canvas.get_tk_widget().create_text(20, 20, text="", anchor="nw")


### PR DESCRIPTION
When in profile mode, clicking anywhere on the figure will store this location as a default value for the "show hyperb" button.